### PR TITLE
Use apt-get for both Debian and Ubuntu installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,16 @@ v 0.2
 
 ### 安装
 
-以 Ubuntu 为例：
+以 Debian/Ubuntu 为例：
 
-    $ sudo aptitude install -y retext git nodejs npm
-    $ sudo ln -fs /usr/bin/nodejs /usr/bin/node
-    $ sudo aptitude install -y calibre fonts-arphic-gbsn00lp
-    $ sudo npm install gitbook-cli -g
+    $ sudo apt-get install retext git nodejs npm
+    $ sudo apt-get install calibre fonts-arphic-gbsn00lp
+    $ sudo npm install gitbook-cli
+    $ sudo rm /usr/local/bin/gitbook
+    $ sudo sh -c 'echo "nodejs /usr/local/lib/node_modules/gitbook-cli/bin/gitbook.js \$@" > /usr/local/bin/gitbook'
+    $ sudo chmod +x /usr/local/bin/gitbook
+    $ gitbook install
+
 
 ### 下载
 


### PR DESCRIPTION
Since package maintainers already configure the path of nodejs, manual symbolic link
is not required.
